### PR TITLE
#30173 (v2): input order must be preserved in script update forms

### DIFF
--- a/admin_site/system/views.py
+++ b/admin_site/system/views.py
@@ -509,7 +509,7 @@ class ScriptMixin(object):
                     'pk': input.pk,
                     'name': input.name,
                     'value_type': input.value_type
-                } for input in self.script.inputs.all()]
+                } for input in self.script.ordered_inputs]
         elif context['script_inputs'] is '':
             context['script_inputs'] = []
 


### PR DESCRIPTION
This is identical to #14 apart from that it uses the existing `ordered_inputs` property to reduce code duplication (and to hide this behaviour behind an API to make it easier to fiddle around with the database later).