### PR TITLE
#31066: malformed notification cookies shouldn't a) break the client or b) exist

### DIFF
--- a/admin_site/site_media/js/custom.js
+++ b/admin_site/site_media/js/custom.js
@@ -39,13 +39,18 @@ var BibOS;
 
       var m = document.cookie.match(/\bbibos-notification\s*=\s*([^;]+)/)
       if(m) {
-        console.log(m[1]);
-        var descriptor = JSON.parse(decodeURIComponent(m[1]));
-        console.log(descriptor);
-        notification = $('.bibos-notification').first()
-        if (descriptor["type"] == "error")
-          notification.addClass("errorlist")
-        notification.html(descriptor["message"]).fadeIn()
+        try {
+          var descriptor = JSON.parse(decodeURIComponent(m[1]));
+          notification = $('.bibos-notification').first()
+          if (descriptor["type"] == "error")
+            notification.addClass("errorlist")
+          notification.html(descriptor["message"]).fadeIn()
+        } catch (e) {
+          /* If there was an exception here, then the cookie was malformed --
+             print the exception to the console and continue, clearing the
+             broken cookie */
+          console.error(e)
+        }
         document.cookie = 'bibos-notification=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/';
       }
 

--- a/admin_site/system/views.py
+++ b/admin_site/system/views.py
@@ -39,7 +39,7 @@ def set_notification_cookie(response, message, error=False):
         "type": "success" if not error else "error"
     }
     response.set_cookie('bibos-notification',
-            quote(json.dumps(descriptor)))
+            quote(json.dumps(descriptor), safe=''))
 
 
 def get_no_of_sec_events(site):


### PR DESCRIPTION
Forward slashes in cookies appear to interact very badly with some part of Django's response framework, resulting in malformed string representations of JSON which the client then can't decode; the resulting exception breaks a bunch of initialisation code, making the UI behave unreliably.

This commit fixes this problem from both directions at once: the client can now gracefully recover from malformed notification cookies, and the server should no longer generate them.