### PR TITLE
[#34665] Gave jobmanager the ability to forcibly stop a frozen precursor

### DIFF
--- a/bibos_client/bibos_client/jobmanager.py
+++ b/bibos_client/bibos_client/jobmanager.py
@@ -226,45 +226,42 @@ class LocalJob(dict):
         self.log(message + "\n")
 
     def run(self):
-        if LOCK.i_am_locking():
-            self.read_property_from_file('status', self.status_path)
-            if self['status'] != 'SUBMITTED':
-                os.sys.stderr.write(
-                    "Job %s: Will only run jobs with status %s\n" % (
-                        self.id,
-                        self['status']
-                    )
-                )
-                return
-            log = open(self.log_path, 'a')
-            self.load_local_parameters()
-            self.set_status('RUNNING')
-            cmd = [self.executable_path]
-            cmd.extend(self['local_parameters'])
-            self.mark_started()
-            log.write(
-                ">>> Starting process '%s' with arguments [%s] at %s\n" % (
-                    self.executable_path,
-                    ', '.join(self['local_parameters']),
-                    self['started']
+        self.read_property_from_file('status', self.status_path)
+        if self['status'] != 'SUBMITTED':
+            os.sys.stderr.write(
+                "Job %s: Will only run jobs with status %s\n" % (
+                    self.id,
+                    self['status']
                 )
             )
-            log.flush()
-            ret_val = subprocess.call(cmd, stdout=log, stderr=log)
-            self.mark_finished()
-            log.flush()
-            if ret_val == 0:
-                self.set_status('DONE')
-                log.write(">>> Succeeded at %s\n" % self['finished'])
-            else:
-                self.set_status('FAILED')
-                log.write(">>> Failed with exit status %s at %s\n" % (
-                    ret_val,
-                    self['finished'])
-                )
-            log.close()
+            return
+        log = open(self.log_path, 'a')
+        self.load_local_parameters()
+        self.set_status('RUNNING')
+        cmd = [self.executable_path]
+        cmd.extend(self['local_parameters'])
+        self.mark_started()
+        log.write(
+            ">>> Starting process '%s' with arguments [%s] at %s\n" % (
+                self.executable_path,
+                ', '.join(self['local_parameters']),
+                self['started']
+            )
+        )
+        log.flush()
+        ret_val = subprocess.call(cmd, stdout=log, stderr=log)
+        self.mark_finished()
+        log.flush()
+        if ret_val == 0:
+            self.set_status('DONE')
+            log.write(">>> Succeeded at %s\n" % self['finished'])
         else:
-            print >> os.sys.stderr, "Will not run job without aquired lock"
+            self.set_status('FAILED')
+            log.write(">>> Failed with exit status %s at %s\n" % (
+                ret_val,
+                self['finished'])
+            )
+        log.close()
 
 
 def get_url_and_uid():
@@ -457,17 +454,14 @@ def get_pending_job_dirs():
 
 def run_pending_jobs():
     dirs = get_pending_job_dirs()
-    if LOCK.i_am_locking():
-        results = []
+    results = []
 
-        for d in dirs:
-            job = LocalJob(path=d)
-            job.run()
-            results.append(job.report_data)
+    for d in dirs:
+        job = LocalJob(path=d)
+        job.run()
+        results.append(job.report_data)
 
-        report_job_results(results)
-    else:
-        print >> os.sys.stderr, "Aquire the lock before running jobs"
+    report_job_results(results)
 
 
 def run_security_scripts():

--- a/bibos_client/bibos_client/utils.py
+++ b/bibos_client/bibos_client/utils.py
@@ -37,6 +37,9 @@ def filelock(file_name, max_age=None):
                 lock_age = time.time() - os.stat(pid_file).st_mtime
                 if lock_age >= max_age:
                     try:
+                        print >> sys.stderr, (
+                                ("warning: forcibly acquiring"
+                                " lock file \"{0}\"").format(file_name))
                         with open(pid_file, "rt") as fp:
                             pid = int(fp.read().strip())
                         os.kill(pid, signal.SIGKILL)

--- a/bibos_client/bibos_client/utils.py
+++ b/bibos_client/bibos_client/utils.py
@@ -10,30 +10,57 @@ import re
 import subprocess
 import fcntl
 
+import contextlib
+import time
+import signal
+import errno
+
 from bibos_utils.bibos_config import BibOSConfig
 from bibos_client.admin_client import BibOSAdmin
 
 
-class filelock(object):
-    """Utility class to implement locks with Unix system calls. This is to
-    avoid the problem with stale locks not detected by the filelock module.
-    """
-    def __init__(self, file_name):
-        self.file_name = file_name
-        self.file_descriptor = None
+@contextlib.contextmanager
+def filelock(file_name, max_age=None):
+    """Acquires the named lock for the lifetime of the context. If the named
+    lock was acquired with this function by another process more than max_age
+    seconds ago, then that process will be forcibly terminated."""
+    pid_file = file_name + ".pid"
+    with open(file_name, "w") as fd:
+        try:
+            # Try to take the lock in the usual way
+            fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except IOError as lock_ex:
+            # If this lock has a maximum age, then check if it's been exceeded.
+            # If it has, then forcibly terminate the locking process and take
+            # the lock
+            if lock_ex.errno == errno.EAGAIN and max_age is not None:
+                lock_age = time.time() - os.stat(pid_file).st_mtime
+                if lock_age >= max_age:
+                    try:
+                        with open(pid_file, "rt") as fp:
+                            pid = int(fp.read().strip())
+                        os.kill(pid, signal.SIGKILL)
+                        fcntl.lockf(fd, fcntl.LOCK_EX)
+                    except ValueError:
+                        raise lock_ex
+                else:
+                    raise lock_ex
+            else:
+                raise lock_ex
 
-    def acquire(self):
-        assert not self.file_descriptor
-        self.file_descriptor = file(self.file_name, 'w')
-        fcntl.lockf(self.file_descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        # XXX RACE BEGINS: we have the lock but haven't written our PID to the
+        # corresponding pidfile yet
+        with open(pid_file, "wt") as fp:
+            fp.write(str(os.getpid()))
+        # XXX RACE ENDS: other processes started after this point will behave
+        # as expected
 
-    def release(self):
-        assert self.file_descriptor
-        fcntl.lockf(self.file_descriptor, fcntl.LOCK_UN)
-        self.file_descriptor = None
-
-    def i_am_locking(self):
-        return self.file_descriptor is not None
+        try:
+            yield
+        finally:
+            os.unlink(pid_file)
+            fcntl.lockf(fd, fcntl.LOCK_UN)
+            os.unlink(file_name)
 
 
 def get_upgrade_packages():


### PR DESCRIPTION
There seem to be some (presently obscure) circumstances in which `jobmanager` freezes while holding the lock. This stops individual OS2borgerPCs from checking in with the administration system until the machine is restarted.

This branch fixes that by rejigging the lock logic a bit: a new `jobmanager` process now has the power to kill an old one if it's held the lock for too long. At the moment, "too long" is hard-coded as 15 minutes; we could make this value either longer or configurable after discussion.

(This change (I _think_ necessarily) introduces a small race condition to the code: `jobmanager` takes the lock and subsequently writes its PID to an associated file. It would, in theory, be possible to start another `jobmanager` in the window between lock acquisition and file flushing, and that new process would behave strangely. On the other hand, this shouldn't be a practical problem: we wait for five minutes between `jobmanager` executions, and if we can't return from a system call and try to write some text to a file in that time, something else has gone very seriously wrong. Comments on this approach would be welcome.)